### PR TITLE
Move model loading into utilities

### DIFF
--- a/scikit_stan/__init__.py
+++ b/scikit_stan/__init__.py
@@ -1,4 +1,7 @@
 from ._version import __version__  # noqa
 from .generalized_linear_regression import GLM
+from .utils.stan import init_local_cmdstan
 
 __all__ = ["GLM"]
+
+init_local_cmdstan()

--- a/scikit_stan/beta_regression/betareg.py-disabled
+++ b/scikit_stan/beta_regression/betareg.py-disabled
@@ -8,13 +8,13 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import scipy.stats as stats
-from cmdstanpy import CmdStanModel, set_cmdstan_path
 from numpy.typing import ArrayLike, NDArray
 
 from scikit_stan.modelcore import CoreEstimator
+from scikit_stan.utils.stan import load_stan_model
 from scikit_stan.utils.validation import (
     FAMILY_LINKS_MAP,
-    GLM_FAMILIES, 
+    GLM_FAMILIES,
     check_array,
     check_is_fitted,
     method_dict,
@@ -23,86 +23,43 @@ from scikit_stan.utils.validation import (
     validate_prior,
 )
 
-STAN_FILES_FOLDER = Path(__file__).parent.parent / "stan_files"
-CMDSTAN_VERSION = "2.30.1"
 
-
-# handle pre-compiled models and possibly repackaged cmdstan
-
-local_cmdstan = STAN_FILES_FOLDER / f"cmdstan-{CMDSTAN_VERSION}"
-if local_cmdstan.exists():
-    set_cmdstan_path(str(local_cmdstan.resolve()))
-
-try:
-    GLM_CONTINUOUS_STAN = CmdStanModel(
-        exe_file=STAN_FILES_FOLDER / "glm_v_continuous.exe",
-        stan_file=STAN_FILES_FOLDER / "glm_v_continuous.stan",
-        compile=False,
-    )
-
-    GLM_DISCRETE_STAN = CmdStanModel(
-        exe_file=STAN_FILES_FOLDER / "glm_v_discrete.exe",
-        stan_file=STAN_FILES_FOLDER / "glm_v_discrete.stan",
-        compile=False,
-    )
-except ValueError:
-    import shutil
-
-    warnings.warn("Failed to load pre-built models, compiling")
-    GLM_CONTINUOUS_STAN = CmdStanModel(
-        stan_file=STAN_FILES_FOLDER / "glm_v_continuous.stan",
-        stanc_options={"O1": True},
-    )
-    GLM_DISCRETE_STAN = CmdStanModel(
-        stan_file=STAN_FILES_FOLDER / "glm_v_discrete.stan",
-        stanc_options={"O1": True},
-    )
-    shutil.copy(
-        GLM_CONTINUOUS_STAN.exe_file,  # type: ignore
-        STAN_FILES_FOLDER / "glm_v_continuous.exe",
-    )
-    shutil.copy(
-        GLM_DISCRETE_STAN.exe_file,  # type: ignore
-        STAN_FILES_FOLDER / "glm_v_discrete.exe",
-    )
-
-
-class BetaReg(CoreEstimator) : 
+class BetaReg(CoreEstimator) :
     r"""
-    Beta regression model following the original statement by Ferrari and Cribari-Neto (2004) 
-    and the extension by Simas, Barreto-Souza, and Rocha (2010). The utility of this model lies 
-    in problems with continuous dependent variables that are restricted to the unit interval, 
-    especially resulting from rates or proportions. 
+    Beta regression model following the original statement by Ferrari and Cribari-Neto (2004)
+    and the extension by Simas, Barreto-Souza, and Rocha (2010). The utility of this model lies
+    in problems with continuous dependent variables that are restricted to the unit interval,
+    especially resulting from rates or proportions.
 
-    The model is beta-distributed using a parameterization of mu and precision parameter phi. 
+    The model is beta-distributed using a parameterization of mu and precision parameter phi.
     As with the GLM in this package, the mean is linked to responses via a link function and
-    linear predictor. Analogously, the precision parameter phi can be linked to another 
-    possibly overlapping set of regressors through an additional link function, which 
-    leads to a model with variable dispersion. 
+    linear predictor. Analogously, the precision parameter phi can be linked to another
+    possibly overlapping set of regressors through an additional link function, which
+    leads to a model with variable dispersion.
 
-    The default link is "log" unless no precision model is specified, in which case 
-    the "identity" link is used. 
-    
-    link : str, optional 
+    The default link is "log" unless no precision model is specified, in which case
+    the "identity" link is used.
+
+    link : str, optional
         Specifies the link function used in the model for mu through the values in the design matrix.
-        The following links are supported: 
+        The following links are supported:
 
-            * "logit", "probit", "cloglog", "cauchit", "log", and "loglog" 
+            * "logit", "probit", "cloglog", "cauchit", "log", and "loglog"
 
-    link_phi : Optional[str], optional 
-        Specifies the link funtion used in the model for phi, the precision parameter, through the values in z, 
-        which is passed to fit() alongside the exogenous data. 
+    link_phi : Optional[str], optional
+        Specifies the link funtion used in the model for phi, the precision parameter, through the values in z,
+        which is passed to fit() alongside the exogenous data.
 
-        The following links are supported: 
+        The following links are supported:
 
             * "identity", "log" (default) and "sqrt"
 
-        Note that the "sqrt" link function is notoriously unstable, so it is advisable to use an alternative. 
+        Note that the "sqrt" link function is notoriously unstable, so it is advisable to use an alternative.
 
     phi_regression : bool, optional
-        Whether or not to have a linear predictor on phi, the precision parameter of the model. 
-        If this is False, then phi is streated as a scalar parameter. Otherwise, as is by default, 
-        with this being True, there is a linear predictor for phi based on the value of z passed to fit(). 
+        Whether or not to have a linear predictor on phi, the precision parameter of the model.
+        If this is False, then phi is streated as a scalar parameter. Otherwise, as is by default,
+        with this being True, there is a linear predictor for phi based on the value of z passed to fit().
 
     priors : Optional[Dict[str, Union[int, float, List]]], optional
         Dictionary for configuring prior distribution on coefficients.
@@ -186,14 +143,14 @@ class BetaReg(CoreEstimator) :
 
         Also note that choosing a Laplace prior is equivalent to L1 regularization:
         https://stats.stackexchange.com/questions/177210/why-is-laplace-prior-producing-sparse-solutions/177217#177217
-    
+
     priors_z : Optional[Dict[str, Union[int, float, List]]], optional
-    
-        Works the same as priors field described above. Defaults and autoscaling are the same. 
+
+        Works the same as priors field described above. Defaults and autoscaling are the same.
 
     prior_intercept_z : Optional[Dict[str, Any]], optional
 
-        Works the same as priors field described above. Defaults and autoscaling are the same. 
+        Works the same as priors field described above. Defaults and autoscaling are the same.
     """
 
 

--- a/scikit_stan/generalized_additive_model/gamm.py-disabled
+++ b/scikit_stan/generalized_additive_model/gamm.py-disabled
@@ -12,10 +12,6 @@ from scikit_stan.utils.validation import (
     validate_prior,
 )
 
-STAN_FILES_FOLDER = Path(__file__).parent.parent / "stan_files"
-CMDSTAN_VERSION = "2.30.1"
-
-
 class GAMM(CoreEstimator):
     """
     Generalized linear additive model with flexible priors.

--- a/scikit_stan/utils/stan.py
+++ b/scikit_stan/utils/stan.py
@@ -1,0 +1,38 @@
+"""
+Module for handling local CmdStan installation and pre-compiled models.
+"""
+import shutil
+import warnings
+from pathlib import Path
+
+from cmdstanpy import CmdStanModel, set_cmdstan_path
+
+STAN_FILES_FOLDER = Path(__file__).parent.parent / "stan_files"
+CMDSTAN_VERSION = "2.30.1"
+
+
+def init_local_cmdstan() -> None:
+    local_cmdstan = STAN_FILES_FOLDER / f"cmdstan-{CMDSTAN_VERSION}"
+    if local_cmdstan.exists():
+        set_cmdstan_path(str(local_cmdstan.resolve()))
+
+
+def load_stan_model(name: str) -> CmdStanModel:
+    try:
+        model = CmdStanModel(
+            exe_file=STAN_FILES_FOLDER / f"{name}.exe",
+            stan_file=STAN_FILES_FOLDER / f"{name}.stan",
+            compile=False,
+        )
+    except ValueError:
+        warnings.warn(f"Failed to load pre-built model '{name}.exe', compiling")
+        model = CmdStanModel(
+            stan_file=STAN_FILES_FOLDER / f"{name}.stan",
+            stanc_options={"O1": True},
+        )
+        shutil.copy(
+            model.exe_file,  # type: ignore
+            STAN_FILES_FOLDER / f"{name}.exe",
+        )
+
+    return model

--- a/scikit_stan/wienerfpt/wfpt.py-disabled
+++ b/scikit_stan/wienerfpt/wfpt.py-disabled
@@ -6,10 +6,10 @@ from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 import scipy.stats as stats
-from cmdstanpy import CmdStanModel, set_cmdstan_path
 from numpy.typing import ArrayLike, NDArray
 
 from scikit_stan.modelcore import CoreEstimator
+from scikit_stan.utils.stan import load_stan_model
 from scikit_stan.utils.validation import (
     check_array,
     check_is_fitted,
@@ -18,9 +18,6 @@ from scikit_stan.utils.validation import (
     validate_family,
     validate_prior,
 )
-
-STAN_FILES_FOLDER = Path(__file__).parent.parent / "stan_files"
-CMDSTAN_VERSION = "2.30.1"
 
 
 class WienerFPT(CoreEstimator):

--- a/test/test_glm.py
+++ b/test/test_glm.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest
 import scipy.sparse as sp
-import scipy.stats as stats  # type: ignore
+import scipy.stats as stats
 from data import _gen_fam_dat_continuous, _gen_fam_dat_discrete, bcdata_dict
 from sklearn.utils.estimator_checks import check_estimator  # type: ignore
 
@@ -597,17 +597,25 @@ def test_poisson_sklearn_poissonregressor():
     )
 
 
-@pytest.mark.skip(reason="Inconsistency with R regression; TBI")
-# TODO: this should have 4 regression coefficients?
 def test_poisson_rstanarm_data():
     # NOTE: this data comes from rstanarm tests
     X = np.array(
-        [[1, 1], [1, 2], [1, 3], [2, 1], [2, 2], [2, 3], [3, 1], [3, 2], [3, 3]]
+        [
+            [1, 1, 1],
+            [1, 2, 1],
+            [1, 3, 1],
+            [1, 1, 2],
+            [1, 2, 2],
+            [1, 3, 2],
+            [1, 1, 3],
+            [1, 2, 3],
+            [1, 3, 3],
+        ]
     )
 
-    y = [18, 17, 15, 20, 10, 20, 25, 13, 12]
+    y = np.array([18, 17, 15, 20, 10, 20, 25, 13, 12])
 
-    glm_poisson = GLM(family="poisson", link="log", seed=1234, algorithm="MLE")
+    glm_poisson = GLM(family="poisson", link="log", seed=1234, algorithm="optimize")
 
     glm_poisson.fit(X=X, y=y)
 


### PR DESCRIPTION
This moves some code out of GLM and into a new module `utils.stan`. This should make it easier to add other models going forward without duplicating code.

